### PR TITLE
Change scope separator to the correct one for pnut (comma)

### DIFF
--- a/lib/passport-pnut/strategy.js
+++ b/lib/passport-pnut/strategy.js
@@ -104,7 +104,6 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       profile.id = json.id;
       profile.username = json.username;
       profile.displayName = json.name;
-      profile.gender = json.gender;
       profile.profileUrl = 'https://pnut.io/@' + json.username;
 
       profile._raw = body;

--- a/lib/passport-pnut/strategy.js
+++ b/lib/passport-pnut/strategy.js
@@ -44,7 +44,7 @@ function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://pnut.io/oauth/authenticate';
   options.tokenURL = options.tokenURL || 'https://api.pnut.io/v0/oauth/access_token';
-  options.scopeSeparator = options.scopeSeparator || '%20';
+  options.scopeSeparator = options.scopeSeparator || ',';
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'pnut';


### PR DESCRIPTION
That one is enough to at least make the module work if one knows how to configure passport-oauth. Previously, a user was forced to set scopeSeparator in the options hash  (who would want to have a configurable scope separator anyway? Seriously, I can't even think of a reason to **have** alternative / configurable separators in the auth URL o_O)