### PR TITLE
Provide currently required options in the strategy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ OAuth tokens.  The strategy requires a `verify` callback, which accepts these
 credentials and calls `done` providing a user, as well as `options` specifying a
 consumer key, consumer secret, and callback URL.
 
+    const PnutStrategy = require("passport-pnut").Strategy;
+
     passport.use(new PnutStrategy({
-        consumerKey: PNUT_CONSUMER_KEY,
-        consumerSecret: PNUT_CONSUMER_SECRET,
+        clientID: PNUT_CLIENT_ID,
+        clientSecret: PNUT_CLIENT_SECRET,
         callbackURL: "http://127.0.0.1:3000/auth/pnut/callback"
       },
       function(token, tokenSecret, profile, done) {


### PR DESCRIPTION
The required identifiers for key/secret are nowadays called clientID and clientSecret.