### PR TITLE
Change package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "passport-pnut",
+  "version": "0.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
+    "passport-oauth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth/-/passport-oauth-1.0.0.tgz",
+      "integrity": "sha1-kK/2M4dUDwIImvKM2tOep/gNd98=",
+      "requires": {
+        "passport-oauth1": "1.1.0",
+        "passport-oauth2": "1.4.0"
+      }
+    },
+    "passport-oauth1": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.1.0.tgz",
+      "integrity": "sha1-p96YiiEfnPRoc3cTDqdN8ycwyRg=",
+      "requires": {
+        "oauth": "0.9.15",
+        "passport-strategy": "1.0.0",
+        "utils-merge": "1.0.1"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.4.0.tgz",
+      "integrity": "sha1-9i+BWDy+EmCb585vFguTlaJ7hq0=",
+      "requires": {
+        "oauth": "0.9.15",
+        "passport-strategy": "1.0.0",
+        "uid2": "0.0.3",
+        "utils-merge": "1.0.1"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "./lib/passport-pnut",
   "dependencies": {
-    "passport-oauth": ">= 0.1.0"
+    "passport-oauth": "^1.0.0"
   },
   "engines": { "node": ">= 0.4.0" },
   "keywords": ["passport", "pnut", "pnutio", "pnut.io", "oauth", "auth", "authn", "authentication", "identity"]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,5 @@
   "dependencies": {
     "passport-oauth": "^1.0.0"
   },
-  "engines": { "node": ">= 0.4.0" },
   "keywords": ["passport", "pnut", "pnutio", "pnut.io", "oauth", "auth", "authn", "authentication", "identity"]
 }


### PR DESCRIPTION
- The ^-Syntax prevents from accidentally upgrading to a incompatible 2.x version in the future
- Engine requirement isn't necessary, at least for a plugin that piggybacks on whatever Passport.js requires
- Lockfiles are default nowadays and always a good idea